### PR TITLE
client/session: Allow setting requested_max_references_per_node

### DIFF
--- a/lib/src/client/session/services.rs
+++ b/lib/src/client/session/services.rs
@@ -338,6 +338,7 @@ pub trait ViewService: Service {
     fn browse(
         &self,
         nodes_to_browse: &[BrowseDescription],
+        requested_max_references_per_node: u32,
     ) -> Result<Option<Vec<BrowseResult>>, StatusCode>;
 
     /// Continue to discover references to nodes by sending continuation points in a [`BrowseNextRequest`]

--- a/lib/src/client/session/session.rs
+++ b/lib/src/client/session/session.rs
@@ -2115,6 +2115,7 @@ impl ViewService for Session {
     fn browse(
         &self,
         nodes_to_browse: &[BrowseDescription],
+        requested_max_references_per_node: u32,
     ) -> Result<Option<Vec<BrowseResult>>, StatusCode> {
         if nodes_to_browse.is_empty() {
             session_error!(self, "browse, was not supplied with any nodes to browse");
@@ -2127,7 +2128,7 @@ impl ViewService for Session {
                     timestamp: DateTime::null(),
                     view_version: 0,
                 },
-                requested_max_references_per_node: 1000,
+                requested_max_references_per_node,
                 nodes_to_browse: Some(nodes_to_browse.to_vec()),
             };
             let response = self.send_request(request)?;


### PR DESCRIPTION
This indicates to servers how many nodes can be included in a response
to a browse request. Some servers abort a connection if the number of
nodes it's trying to inlude in a browse response is too many.

Change the signature of browse() to allow passing in a custom maximum
which can help as a workaround.