### PR TITLE
Enable mend (aka Whitesource) dependency vulnerability scanning

### DIFF
--- a/.whitesource
+++ b/.whitesource
@@ -1,0 +1,3 @@
+{
+  "settingsInheritedFrom": "whitesource-config/whitesource-config@issues_none"
+}


### PR DESCRIPTION
This PR just adds a small json file that turns on meld (formerly whitesource) security scans:
https://www.mend.io/sca/